### PR TITLE
Align BearsiMac with NixOS 24.05 KDE

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720535198,
-        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "BearsiMac - Willowie Kitchen NixOS Configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
   };
 
   outputs = { self, nixpkgs }: let

--- a/modules/atlas.nix
+++ b/modules/atlas.nix
@@ -30,11 +30,14 @@ in
   users.users.atlas = {
     isSystemUser = true;
     description = "Atlas runtime user";
+    group = "atlas";
     createHome = false;
     home = "/var/lib/atlas";
     extraGroups = [ ];
     shell = "/sbin/nologin";
   };
+
+  users.groups.atlas = { };
 
   systemd.services."atlas-frontend" = {
     description = "Atlas frontend (bridge)";

--- a/modules/atlas.nix
+++ b/modules/atlas.nix
@@ -17,7 +17,14 @@ in
   services.mosquitto = {
     enable = true;
     package = pkgs.mosquitto;
-    bindAddress = "127.0.0.1";
+    listeners = [
+      {
+        address = "127.0.0.1";
+        port = 1883;
+        omitPasswordAuth = true;
+        settings.allow_anonymous = true;
+      }
+    ];
   };
 
   users.users.atlas = {

--- a/modules/atlas.nix
+++ b/modules/atlas.nix
@@ -12,7 +12,7 @@ in
     podman
   ];
 
-  services.node_exporter.enable = true;
+  services.prometheus.exporters.node.enable = true;
 
   services.mosquitto = {
     enable = true;

--- a/modules/field-integration.nix
+++ b/modules/field-integration.nix
@@ -22,15 +22,30 @@ with lib;
       description = "Identity string for SOMA sphere";
     };
     
-    trainStation = mkOption {
-      type = types.attrs;
-      default = {
-        frequency = 852;
-        position = "center";
-        symbol = "🚂";
-        chakra = "Crown Base";
+    trainStation = {
+      frequency = mkOption {
+        type = types.int;
+        default = 852;
+        description = "Train Station center frequency.";
       };
-      description = "Train Station orchestrator configuration";
+
+      position = mkOption {
+        type = types.str;
+        default = "center";
+        description = "Train Station position in the SOMA octahedron.";
+      };
+
+      symbol = mkOption {
+        type = types.str;
+        default = "🚂";
+        description = "Train Station display symbol.";
+      };
+
+      chakra = mkOption {
+        type = types.str;
+        default = "Crown Base";
+        description = "Train Station chakra alignment.";
+      };
     };
     
     vertices = mkOption {

--- a/nixosConfigurations/BearsiMac/configuration.nix
+++ b/nixosConfigurations/BearsiMac/configuration.nix
@@ -127,7 +127,6 @@
     zsh
     htop
     firefox
-    gnome.gnome-tweaks
   ];
 
   # Enable important services
@@ -146,16 +145,16 @@
         PasswordAuthentication = true;
       };
     };
-    # Enable X11 and GNOME Desktop
+    # Enable X11 and the authentic KDE Plasma desktop
     xserver = {
       enable = true;
-      displayManager.gdm.enable = true;
-      desktopManager.gnome.enable = true;
+      displayManager.sddm.enable = true;
+      desktopManager.plasma5.enable = true;
       # For iMac's AMD Radeon graphics
       videoDrivers = [ "amdgpu" ];
     };
   };
 
   # System state version
-  system.stateVersion = "23.11";
+  system.stateVersion = "24.05";
 }

--- a/nixosConfigurations/BearsiMac/configuration.nix
+++ b/nixosConfigurations/BearsiMac/configuration.nix
@@ -146,9 +146,9 @@
       };
     };
     # Enable X11 and the authentic KDE Plasma desktop
+    displayManager.sddm.enable = true;
     xserver = {
       enable = true;
-      displayManager.sddm.enable = true;
       desktopManager.plasma5.enable = true;
       # For iMac's AMD Radeon graphics
       videoDrivers = [ "amdgpu" ];

--- a/nixosConfigurations/BearsiMac/configuration.nix
+++ b/nixosConfigurations/BearsiMac/configuration.nix
@@ -3,7 +3,7 @@
 { config, lib, pkgs, ... }:
 {
   imports = [
-    ../../../modules/services/copilot-assistant-flake.nix
+    ../../modules/services/copilot-assistant-flake.nix
     ./hardware-configuration.nix
     ../../dot-hive/default.nix
     ../../modules/atlas.nix


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Update the root nixpkgs input and lock file from `nixos-23.11` to `nixos-24.05`.
- Restore BearsiMac to SDDM + KDE Plasma 5, set BearsiMac `system.stateVersion` to `24.05`, and remove the GNOME Tweaks package.
- Fix evaluation blockers exposed by the 24.05 channel switch: BearsiMac module import path, composable Train Station nested options, current Mosquitto listener syntax, current Node Exporter option, and the Atlas system user group assertion.

### Testing
- `nix flake show --extra-experimental-features "nix-command flakes"` passes and lists all four NixOS configurations.
- `nix eval .#nixosConfigurations.BearsiMac.config.system.build.toplevel.drvPath --impure --extra-experimental-features "nix-command flakes"` passes and returns a BearsiMac 24.05 system derivation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ace7938b-eeba-4bc3-b0f9-0fa9aa0ddb07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ace7938b-eeba-4bc3-b0f9-0fa9aa0ddb07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

